### PR TITLE
Remove the final dot added by dblp in paper title

### DIFF
--- a/app/repositories/scraper-repository/scrapers/dblp.ts
+++ b/app/repositories/scraper-repository/scrapers/dblp.ts
@@ -92,7 +92,7 @@ export class DBLPScraper extends Scraper {
         if (plainHitTitle != existTitle) {
           continue;
         } else {
-          const title = article.title.replace(/&amp;/g, "&");
+          const title = article.title.replace(/&amp;/g, "&").replace(/\.$/, '');
 
           const authorList = [];
           const authorResponse = article.authors.author;


### PR DESCRIPTION
It is weird that dblp will always add a dot `.` to the end of paper title. We can remove the dot in paperlib to ensure the consistency of paper title among all the scrapers.