### PR TITLE
Fix downloader delete button display bug

### DIFF
--- a/app/renderer/ui/preference-view/components/downloader.vue
+++ b/app/renderer/ui/preference-view/components/downloader.vue
@@ -69,7 +69,7 @@ const onApplyUpdate = () => {
           v-if="downloaderPref.custom"
           @click="emit('delete', downloaderPref.name)"
         >
-          {{ $t("mainview.delete") }}
+          {{ $t("menu.delete") }}
         </div>
         <input
           type="checkbox"


### PR DESCRIPTION
It was caused by inconsistent reference names between the translation file and the code.