### PR TITLE
Fix empty options show in multiselect box

### DIFF
--- a/app/renderer/ui/edit-view/components/multiselect-box.vue
+++ b/app/renderer/ui/edit-view/components/multiselect-box.vue
@@ -181,9 +181,9 @@ onUnmounted(() => {
       />
     </div>
     <div
-      class="bg-neutral-300 fixed max-h-24 rounded-md shadow-md flex flex-col p-1 overflow-scroll"
+      class="bg-neutral-300 fixed max-h-24 rounded-md shadow-md flex flex-col p-1 overflow-y-scroll"
       :style="`width: ${boxWidth}px; margin-top: ${boxHeight + 2}px`"
-      v-if="isFocused || isMouseOver"
+      v-if="filteredOptions.length > 0 && (isFocused || isMouseOver)"
       ref="dropdown"
     >
       <div


### PR DESCRIPTION
Fixed when the list of options is empty, the dropdown box will still be displayed.