### PR TITLE
Fix installed plugins still show download btn

### DIFF
--- a/app/renderer/ui/preference-view/extension-view.vue
+++ b/app/renderer/ui/preference-view/extension-view.vue
@@ -363,9 +363,12 @@ onUnmounted(async () => {
             :author="extension.author"
             :description="extension.description"
             :homepage="extension.homepage"
-            :installed="false"
+            :installed="installedExtensions.hasOwnProperty(extension.id)"
             :installing="installingExtIDs.includes(extension.id)"
             @event:install="installExtension(extension.id)"
+            @event:reload="reloadExtension(extension.id)"
+            @event:uninstall="uninstallExtension(extension.id)"
+            @event:setting="showSettingView(extension.id)"
           />
         </div>
       </div>


### PR DESCRIPTION
Or just remove already installed plugin?

<img width="766" alt="image" src="https://github.com/Future-Scholars/paperlib/assets/12986082/94e5d0e2-269a-402f-9dc7-9ff37dda2815">

