### PR TITLE
Dependency: bump up electron

### DIFF
--- a/app/base/network.ts
+++ b/app/base/network.ts
@@ -80,10 +80,14 @@ export class NetworkTool {
     }
   }
 
-  private async _parseResponse(response: Response) {
+  private async _parseResponse(response: Response, parse = true) {
     const contentType = response.headers["content-type"];
     let body: any;
-    if (contentType?.includes("application/json")) {
+    if (
+      contentType?.includes("application/json") &&
+      parse &&
+      (response.body instanceof String || typeof response.body === "string")
+    ) {
       body = JSON.parse(response.body as string);
     } else {
       body = response.body;
@@ -173,6 +177,7 @@ export class NetworkTool {
    * @param retry - Retry times
    * @param timeout - Timeout
    * @param cache - Use cache
+   * @param parse - Try to parse response body
    * @returns Response
    */
   async get(
@@ -180,7 +185,8 @@ export class NetworkTool {
     headers?: Record<string, string>,
     retry = 1,
     timeout = 5000,
-    cache = false
+    cache = false,
+    parse = false
   ) {
     const options = {
       headers: headers,
@@ -194,9 +200,9 @@ export class NetworkTool {
     };
 
     if (cache) {
-      return this._parseResponse(await cachedGot.get(url, options));
+      return this._parseResponse(await cachedGot.get(url, options), parse);
     } else {
-      return this._parseResponse(await got.get(url, options));
+      return this._parseResponse(await got.get(url, options), parse);
     }
   }
 
@@ -216,7 +222,8 @@ export class NetworkTool {
     headers?: Record<string, string>,
     retry = 1,
     timeout = 5000,
-    compress = false
+    compress = false,
+    parse = false
   ) {
     let options: OptionsOfTextResponseBody = {
       headers: headers,
@@ -237,7 +244,7 @@ export class NetworkTool {
     } else {
       options.body = data;
     }
-    return this._parseResponse(await got.post(url, options));
+    return this._parseResponse(await got.post(url, options), parse);
   }
 
   /**
@@ -254,7 +261,8 @@ export class NetworkTool {
     data: FormData,
     headers?: Record<string, string>,
     retry = 1,
-    timeout = 5000
+    timeout = 5000,
+    parse = false
   ) {
     if (!(data instanceof FormData)) {
       if (typeof data === "object") {
@@ -277,7 +285,7 @@ export class NetworkTool {
       },
       agent: this._agent,
     };
-    return this._parseResponse(await got.post(url, options));
+    return this._parseResponse(await got.post(url, options), parse);
   }
 
   /**

--- a/app/extension/services/extension-management-service.ts
+++ b/app/extension/services/extension-management-service.ts
@@ -364,7 +364,12 @@ export class ExtensionManagementService extends Eventable<IExtensionManagementSe
         await PLAPI.networkTool.get(
           query
             ? `https://registry.npmjs.org/-/v1/search?text=${query} keywords:paperlib&size=20`
-            : "https://registry.npmjs.org/-/v1/search?text=keywords:paperlib&size=20"
+            : "https://registry.npmjs.org/-/v1/search?text=keywords:paperlib&size=20",
+          {},
+          1,
+          10000,
+          false,
+          true
         )
       ).body.objects as {
         package: {

--- a/app/locales/locales/en.GB.json
+++ b/app/locales/locales/en.GB.json
@@ -44,6 +44,7 @@
     "toggleflag": "Toggle Flag",
     "listview": "List View",
     "tableview": "Table View",
+    "tablereaderview": "Table Reader View",
     "preference": "Preference",
     "title": "Title",
     "authors": "Authors",

--- a/app/locales/locales/zh.CN.json
+++ b/app/locales/locales/zh.CN.json
@@ -44,6 +44,7 @@
     "toggleflag": "切换标记",
     "listview": "列表视图",
     "tableview": "表格视图",
+    "tablereaderview": "表格阅读视图",
     "preference": "设置",
     "title": "标题",
     "authors": "作者",

--- a/app/renderer/ui/main-view/menubar-view/components/menu-bar-btn.vue
+++ b/app/renderer/ui/main-view/menubar-view/components/menu-bar-btn.vue
@@ -35,7 +35,7 @@ const btnIcons: Record<string, any> = {
   listview: BIconListUl,
   tableview: BIconGrid3x2,
   preference: BIconGear,
-  aspectratio: BIconAspectRatio,
+  tablereaderview: BIconAspectRatio,
 };
 </script>
 

--- a/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
+++ b/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
@@ -112,7 +112,7 @@ const onMaximizeClicked = () => {
         <MenuBarBtn
           id="table-reader-view-btn"
           class="my-auto"
-          btnName="aspectratio"
+          btnName="tablereaderview"
           @event:click="emits('event:click', 'tableandpreview-view')"
         />
       </div>

--- a/app/renderer/ui/whats-new-view/whats-new-view.vue
+++ b/app/renderer/ui/whats-new-view/whats-new-view.vue
@@ -17,7 +17,12 @@ const loadCurrent = async () => {
   const response = await networkTool.get(
     `https://api.paperlib.app/release-notes/json?lang=${
       preState.language === "zh-CN" ? "CN" : "EN"
-    }&latest=1&branch=dev-3.0.0`
+    }&latest=1&branch=dev-3.0.0`,
+    {},
+    1,
+    10000,
+    true,
+    true
   );
 
   const json = response.body;
@@ -37,7 +42,12 @@ const loadHistory = async () => {
   const response = await networkTool.get(
     `https://api.paperlib.app/release-notes/html?lang=${
       preState.language === "zh-CN" ? "CN" : "EN"
-    }&latest=5&branch=dev-3.0.0`
+    }&latest=5&branch=dev-3.0.0`,
+    {},
+    1,
+    10000,
+    true,
+    true
   );
 
   historyReleaseNoteHTML.value = response.body;

--- a/app/repositories/rss-repository/rss-repository.ts
+++ b/app/repositories/rss-repository/rss-repository.ts
@@ -15,7 +15,14 @@ export class RSSRepository {
   }
 
   async fetch(feed: Feed): Promise<FeedEntity[]> {
-    const response = await this._networkTool.get(feed.url);
+    const response = await this._networkTool.get(
+      feed.url,
+      {},
+      1,
+      10000,
+      false,
+      true
+    );
 
     let feedEntityDrafts = this.parse(response.body);
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bson": "4.6.3",
     "citation-js": "0.6.4",
     "cssnano": "5.1.7",
-    "electron": "22.3.27",
+    "electron": "26.6.5",
     "electron-builder": "23.6.0",
     "electron-log": "4.4.8",
     "fast-xml-parser": "4.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ devDependencies:
     specifier: 5.1.7
     version: 5.1.7(postcss@8.4.33)
   electron:
-    specifier: 22.3.27
-    version: 22.3.27
+    specifier: 26.6.5
+    version: 26.6.5
   electron-builder:
     specifier: 23.6.0
     version: 23.6.0
@@ -1290,8 +1290,10 @@ packages:
       form-data: 4.0.0
     dev: false
 
-  /@types/node@16.18.69:
-    resolution: {integrity: sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg==}
+  /@types/node@18.19.6:
+    resolution: {integrity: sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/node@20.10.6:
@@ -1369,7 +1371,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.69
+      '@types/node': 20.10.6
     dev: true
     optional: true
 
@@ -2803,14 +2805,14 @@ packages:
       - supports-color
     dev: false
 
-  /electron@22.3.27:
-    resolution: {integrity: sha512-7Rht21vHqj4ZFRnKuZdFqZFsvMBCmDqmjetiMqPtF+TmTBiGne1mnstVXOA/SRGhN2Qy5gY5bznJKpiqogjM8A==}
+  /electron@26.6.5:
+    resolution: {integrity: sha512-1zgit3HfMJmTgYQraZs72QJJuHlYOIvI7vk4bcIrVvU5vnA0lK3rQypEBpRB+DbfUz/0jYkvWiLPSdehBjKBFg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 16.18.69
+      '@types/node': 18.19.6
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -5228,6 +5230,7 @@ packages:
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /semver@7.0.0:


### PR DESCRIPTION
@charlieJ107 @ischaojie 

I decide to bump up the version of `Electron` to `26.6.5` in this PR. Please rebase your development branch onto the newest `dev-3.0.0`, delete `node_modules`, and `pnpm install`.

`Electron 26.6.5` is the last version to support macOS Mojave. Currently we cannot upgrade to a higher version as I do know some users are still using Mojave.