### PR TITLE
Feat(title-bar): support unmaximizing on Windows

### DIFF
--- a/app/main/services/window-process-management-service.ts
+++ b/app/main/services/window-process-management-service.ts
@@ -328,12 +328,6 @@ export class WindowProcessManagementService extends Eventable<IWindowProcessMana
     if (windowId === Process.renderer) {
       const win = this.browserWindows.get(windowId);
       win.unmaximize();
-
-      for (const [windowId, win] of Object.entries(this.browserWindows.all())) {
-        if (windowId !== Process.renderer) {
-          win.unmaximize();
-        }
-      }
     }
   }
 

--- a/app/main/services/window-process-management-service.ts
+++ b/app/main/services/window-process-management-service.ts
@@ -132,6 +132,8 @@ export class WindowProcessManagementService extends Eventable<IWindowProcessMana
       "focus",
       "close",
       "show",
+      "unmaximize",
+      "maximize"
     ]) {
       this.browserWindows.get(id).on(eventName as any, (e) => {
         this.fire({ [id]: eventName });
@@ -313,6 +315,23 @@ export class WindowProcessManagementService extends Eventable<IWindowProcessMana
       for (const [windowId, win] of Object.entries(this.browserWindows.all())) {
         if (windowId !== Process.renderer) {
           win.hide();
+        }
+      }
+    }
+  }
+
+  /**
+   * Unmaximize the window with the given id.
+   * @param windowId - The id of the window to be unmaximized
+   */
+  unmaximize(windowId: string) {
+    if (windowId === Process.renderer) {
+      const win = this.browserWindows.get(windowId);
+      win.unmaximize();
+
+      for (const [windowId, win] of Object.entries(this.browserWindows.all())) {
+        if (windowId !== Process.renderer) {
+          win.unmaximize();
         }
       }
     }

--- a/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
+++ b/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
@@ -22,6 +22,8 @@ import {
 import { Process } from "@/base/process-id";
 import CommandBar from "./components/command-bar.vue";
 import MenuBarBtn from "./components/menu-bar-btn.vue";
+import { disposable } from "@/base/dispose.ts";
+import { ref } from "vue";
 
 const props = defineProps({
   disableSingleBtn: {
@@ -42,6 +44,8 @@ const emits = defineEmits(["event:click"]);
 const uiState = uiStateService.useState();
 const prefState = preferenceService.useState();
 
+const isMaximized = ref(false)
+
 const onCloseClicked = () => {
   PLMainAPI.windowProcessManagementService.close(Process.renderer);
 };
@@ -50,9 +54,28 @@ const onMinimizeClicked = () => {
   PLMainAPI.windowProcessManagementService.minimize(Process.renderer);
 };
 
+const onUnmaximizeClicked = () => {
+  PLMainAPI.windowProcessManagementService.unmaximize(Process.renderer);
+};
+
 const onMaximizeClicked = () => {
   PLMainAPI.windowProcessManagementService.maximize(Process.renderer);
 };
+
+
+disposable(
+  PLMainAPI.windowProcessManagementService.on(
+    Process.renderer,
+    (newValue: { value: string }) => {
+      if (newValue.value === "unmaximize") {
+        isMaximized.value = false
+      } else if (newValue.value === "maximize") {
+        isMaximized.value = true
+      }
+    }
+  )
+)
+
 </script>
 
 <template>
@@ -376,6 +399,16 @@ const onMaximizeClicked = () => {
         <BIconDash class="text-lg text-neutral-500" />
       </div>
       <div
+        v-if="isMaximized"
+        class="flex w-10 h-8 hover:bg-neutral-300 transition ease-in-out justify-center items-center"
+        @click="onUnmaximizeClicked"
+      >
+        <div
+          class="w-[8px] h-[8px] border-[1.5px] border-neutral-500"
+        ></div>
+      </div>
+      <div
+        v-else
         class="flex w-10 h-8 hover:bg-neutral-300 transition ease-in-out justify-center items-center"
         @click="onMaximizeClicked"
       >

--- a/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
+++ b/app/renderer/ui/main-view/menubar-view/window-menu-bar.vue
@@ -403,9 +403,9 @@ disposable(
         class="flex w-10 h-8 hover:bg-neutral-300 transition ease-in-out justify-center items-center"
         @click="onUnmaximizeClicked"
       >
-        <div
-          class="w-[8px] h-[8px] border-[1.5px] border-neutral-500"
-        ></div>
+        <div class="h-[8px] w-[8px] border-[1px] border-neutral-500 rounded-sm">
+          <div class="relative right-[-2px] top-[-3px] h-[8px] w-[8px] rounded-sm border-r-[1px] border-t-[1px] border-neutral-500"></div>
+        </div>
       </div>
       <div
         v-else


### PR DESCRIPTION
Users can only maximize the window on Windows. This PR will try to support unmaximizing on Windows.

![image](https://github.com/Future-Scholars/paperlib/assets/27353191/899853c9-1686-45c5-9540-70adb343a122)

However, I just created a simple unmaximizing button. I think it's better to keep up with other apps on Windows. And bootstrap-icons-vue doesn't support that icon. Maybe we need to import external icons.

![image](https://github.com/Future-Scholars/paperlib/assets/27353191/12a5e38e-9dce-4e1a-86c0-9bad3502b40b)
