### PR TITLE
fix: invalid global shortcuts

### DIFF
--- a/app/main/services/menu-service.ts
+++ b/app/main/services/menu-service.ts
@@ -238,11 +238,7 @@ export class MenuService extends Eventable<IMenuServiceState> {
    * Disable all global shortcuts.
    */
   disableGlobalShortcuts() {
-    const pluginKey = this._preferenceService.get("shortcutPlugin");
-    if (!pluginKey) {
-      return;
-    }
-    globalShortcut.unregister(pluginKey as string);
+    globalShortcut.unregisterAll();
   }
 
   /**

--- a/app/renderer/ui/preference-view/hotkey-view.vue
+++ b/app/renderer/ui/preference-view/hotkey-view.vue
@@ -92,6 +92,11 @@ const onUpdate = (key: keyof IPreferenceStore, value: string) => {
   info.value = "";
   preferenceService.set({ [key]: newShortcut });
 };
+const onGlobalShortcutChange=(key:string)=>{
+  onUpdate('shortcutPlugin', key)
+  PLMainAPI.menuService.disableGlobalShortcuts();
+  PLMainAPI.menuService.enableGlobalShortcuts();
+}
 </script>
 
 <template>
@@ -125,7 +130,7 @@ const onUpdate = (key: keyof IPreferenceStore, value: string) => {
       <HotkeyOption
         :title="$t('preference.hotkeysPluginLabel')"
         :choosed-key="prefState.shortcutPlugin"
-        @event:change="(key) => onUpdate('shortcutPlugin', key)"
+        @event:change="onGlobalShortcutChange"
       />
       <HotkeyOption
         :title="$t('menu.copybibtext')"


### PR DESCRIPTION
In some scenarios, `enableGlobalShortcuts `and `disableGlobalShortcuts` can't get the latest preference value, leading to incorrect global shortcuts.