### PR TITLE
refactor: make shortcut event robust

### DIFF
--- a/app/common/utils.ts
+++ b/app/common/utils.ts
@@ -12,9 +12,7 @@ export interface ShortcutEvent {
   preventDefault?: () => void;
   stopPropagation?: () => void;
   isInput?: boolean;
-  target?: {
-    blur?: () => void;
-  };
+  target?: EventTarget | null;
 }
 
 export const formatShortcut = (
@@ -81,12 +79,6 @@ export const convertKeyboardEvent = (e: KeyboardEvent): ShortcutEvent => {
       e.stopPropagation();
     },
     isInput,
-    target: {
-      blur: () => {
-        if (isInput && e.target) {
-          (e.target as HTMLInputElement | HTMLTextAreaElement).blur();
-        }
-      },
-    },
+    target: e.target,
   };
 };

--- a/app/renderer/ui/main-view/menubar-view/components/command-bar.vue
+++ b/app/renderer/ui/main-view/menubar-view/components/command-bar.vue
@@ -194,7 +194,9 @@ const onFocus = async (payload: Event) => {
   escapeDisposeHandler = shortcutService.register(
     "Escape",
     (e: ShortcutEvent) => {
-      e.target?.blur?.();
+      if (e.isInput && e.target) {
+        (e.target as HTMLInputElement | HTMLTextAreaElement).blur();
+      }
       uiState.commandBarText = "";
       uiState.commandBarSearchMode = "general";
       uiState.querySentenceCommandbar = "";


### PR DESCRIPTION
To fix #486 , we implemented the blur method for `ShortcutEvent`. But it is better to pass the whole event target.