### PR TITLE
fix: 403 Forbidden When Requesting ScienceDirect RSS

### DIFF
--- a/app/repositories/rss-repository/rss-repository.ts
+++ b/app/repositories/rss-repository/rss-repository.ts
@@ -14,9 +14,17 @@ export class RSSRepository {
   }
 
   async fetch(feed: Feed): Promise<FeedEntity[]> {
+
+    const header = {};
+
+    if (feed.url.includes("rss.sciencedirect.com")) {
+      // Since May 2024, ScienceDirect seems has blocked requests with robot user agents.
+      header["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0"
+    }
+
     const response = await PLExtAPI.networkTool.get(
       feed.url,
-      {},
+      header,
       1,
       10000,
       false,


### PR DESCRIPTION
Fix #531 

ScienceDirect RSS endpoints seem to block requests without or with the robot `User-Agent` header. This PR added the header to pretend the Edge browser Version 125.0.2535.51 (Official build) (64-bit). After a simple local test, the ScienceDirect RSS feeds can be refreshed successfully. 

When reviewing this PR, please double-check that it works on different platforms or network environments. 

Note: Honestly, I don't understand why ScienceDirect blocks requests with Robot `User-Agent` headers. This means that many RSS management tools may no longer be able to refresh properly without doing anything else. Disguising request headers isn't an honest (but expected and not prohibited) means.