### PR TITLE
feat: import files via an dialog picker

### DIFF
--- a/app/common/services/preference-service.ts
+++ b/app/common/services/preference-service.ts
@@ -77,6 +77,8 @@ export interface IPreferenceStore {
 
   shortcutDelete: string;
 
+  shortcutImportFrom: string;
+
   sidebarWidth: number;
   detailPanelWidth: number;
   mainviewSortBy: string;
@@ -195,6 +197,8 @@ const _defaultPreferences: IPreferenceStore = {
   shortcutCopyKey: `${cmdOrCtrl}+Shift+K`,
 
   shortcutDelete: "Delete",
+
+  shortcutImportFrom: `${cmdOrCtrl}+O`,
 
   sidebarWidth: 20,
   detailPanelWidth: 75,

--- a/app/locales/locales/en.GB.json
+++ b/app/locales/locales/en.GB.json
@@ -91,6 +91,7 @@
     "asc": "Ascending",
     "export": "Export",
     "open": "Open",
+    "importfrom": "Import from...",
     "showinfinder": "Show in Finder",
     "showinexplore": "Show in Explorer",
     "bibtexkey": "BibTeX Key",

--- a/app/locales/locales/zh.CN.json
+++ b/app/locales/locales/zh.CN.json
@@ -91,6 +91,7 @@
     "asc": "升序",
     "export": "导出",
     "open": "打开",
+    "importfrom": "从文件导入...",
     "showinfinder": "在访达中显示",
     "showinexplore": "在资源管理器中显示",
     "bibtexkey": "BibTeX 键",

--- a/app/locales/locales/zh.TW.json
+++ b/app/locales/locales/zh.TW.json
@@ -91,6 +91,7 @@
     "asc": "陞序",
     "export": "匯出",
     "open": "打開",
+    "importfrom": "自文件匯入...",
     "showinfinder": "在 Finder 中顯示",
     "showinexplore": "在檔案總管中顯示",
     "bibtexkey": "BibTeX 鍵",

--- a/app/main/services/filesystem-service.ts
+++ b/app/main/services/filesystem-service.ts
@@ -78,9 +78,13 @@ export class FileSystemService {
    * @returns {Promise<OpenDialogReturnValue>} The result of the file picker.
    */
   @errorcatching("Failed to show file picker.", true, "FileSystemService")
-  showFilePicker(): Promise<OpenDialogReturnValue> {
+  showFilePicker(props?: Array<"openDirectory" | "multiSelections" | "showHiddenFiles" | "createDirectory" | "promptToCreate" | "noResolveAliases" | "treatPackageAsDirectory" | "dontAddToRecent">): Promise<OpenDialogReturnValue> {
+    const properties: Array<"openFile" | "openDirectory" | "multiSelections" | "showHiddenFiles" | "createDirectory" | "promptToCreate" | "noResolveAliases" | "treatPackageAsDirectory" | "dontAddToRecent"> = ["openFile"];
+    if (props) {
+      properties.push(...props);
+    }
     return dialog.showOpenDialog({
-      properties: ["openFile"],
+      properties,
     });
   }
 

--- a/app/main/services/menu-service.ts
+++ b/app/main/services/menu-service.ts
@@ -25,6 +25,7 @@ export interface IMenuServiceState {
   "View-next": number;
   "View-previous": number;
   "File-delete": number;
+  "File-importFrom": number;
 }
 
 export const IMenuService = createDecorator("menuService");
@@ -49,6 +50,7 @@ export class MenuService extends Eventable<IMenuServiceState> {
       "View-next": 0,
       "View-previous": 0,
       "File-delete": 0,
+      "File-importFrom": 0,
     });
 
     this._locales = loadLocales(
@@ -67,33 +69,33 @@ export class MenuService extends Eventable<IMenuServiceState> {
     const template = [
       ...(isMac
         ? [
-            {
-              label: app.name,
-              submenu: [
-                { role: "about" },
-                {
-                  label: this._locales.t("menu.preference"),
-                  click: () => {
-                    this.fire("preference");
-                  },
+          {
+            label: app.name,
+            submenu: [
+              { role: "about" },
+              {
+                label: this._locales.t("menu.preference"),
+                click: () => {
+                  this.fire("preference");
                 },
-                {
-                  label: this._locales.t("menu.checkforupdate"),
-                  click: () => {
-                    this._upgradeService.checkForUpdates();
-                  },
+              },
+              {
+                label: this._locales.t("menu.checkforupdate"),
+                click: () => {
+                  this._upgradeService.checkForUpdates();
                 },
-                { type: "separator" },
-                { role: "services" },
-                { type: "separator" },
-                { role: "hide" },
-                { role: "hideOthers" },
-                { role: "unhide" },
-                { type: "separator" },
-                { role: "quit" },
-              ],
-            },
-          ]
+              },
+              { type: "separator" },
+              { role: "services" },
+              { type: "separator" },
+              { role: "hide" },
+              { role: "hideOthers" },
+              { role: "unhide" },
+              { type: "separator" },
+              { role: "quit" },
+            ],
+          },
+        ]
         : []),
       {
         label: this._locales.t("menu.file"),
@@ -102,6 +104,14 @@ export class MenuService extends Eventable<IMenuServiceState> {
             label: this._locales.t("menu.open"),
             click: () => {
               this.fire("File-enter");
+            },
+          },
+          { type: "separator" },
+          {
+            label: this._locales.t("menu.importfrom"),
+            accelerator: isMac ? "Cmd+O" : "Ctrl+O",
+            click: () => {
+              this.fire("File-importFrom");
             },
           },
           { type: "separator" },
@@ -197,11 +207,11 @@ export class MenuService extends Eventable<IMenuServiceState> {
           { role: "zoom" },
           ...(isMac
             ? [
-                { type: "separator" },
-                { role: "front" },
-                { type: "separator" },
-                { role: "window" },
-              ]
+              { type: "separator" },
+              { role: "front" },
+              { type: "separator" },
+              { role: "window" },
+            ]
             : [{ role: "close" }]),
         ],
       },

--- a/app/main/services/menu-service.ts
+++ b/app/main/services/menu-service.ts
@@ -109,7 +109,7 @@ export class MenuService extends Eventable<IMenuServiceState> {
           { type: "separator" },
           {
             label: this._locales.t("menu.importfrom"),
-            accelerator: isMac ? "Cmd+O" : "Ctrl+O",
+            // accelerator: isMac ? "Cmd+O" : "Ctrl+O",
             click: () => {
               this.fire("File-importFrom");
             },

--- a/app/renderer/ui/main-view/main-view.vue
+++ b/app/renderer/ui/main-view/main-view.vue
@@ -406,6 +406,22 @@ const switchSortOrder = (order: "asce" | "desc") => {
   preferenceService.set({ mainviewSortOrder: order });
 };
 
+const importFilesFromPicker = async () => {
+  const pickedFiles = await PLMainAPI.fileSystemService.showFilePicker([
+    "multiSelections",
+  ]);
+  if (pickedFiles.canceled || !pickedFiles) {
+    console.log("Picking files canceled or no files picked.");
+    return;
+  }
+  const filePaths: string[] = [];
+  pickedFiles.filePaths.forEach((filePath) => {
+    filePaths.push(`file://${filePath}`);
+    console.log("Picked file path: ", filePath);
+  });
+  await paperService.create(filePaths);
+};
+
 const onMenuButtonClicked = (command: string) => {
   switch (command) {
     case "rescrape":
@@ -677,6 +693,12 @@ disposable(
     true,
     true
   )
+);
+
+disposable(
+  PLMainAPI.menuService.onClick("File-importFrom", () => {
+    importFilesFromPicker();
+  })
 );
 
 disposable(

--- a/app/renderer/ui/main-view/main-view.vue
+++ b/app/renderer/ui/main-view/main-view.vue
@@ -153,6 +153,19 @@ const registerShortcutFromPreference = () => {
       shortcutService.viewScope.MAIN
     )
   );
+
+
+  disposeCallbacks.push(
+    shortcutService.register(
+      preferenceService.get("shortcutImportFrom") as string,
+      () => {
+        PLMainAPI.menuService.click("File-importFrom");
+      },
+      true,
+      true,
+      shortcutService.viewScope.MAIN
+    )
+  );
 };
 
 preferenceService.on(
@@ -411,13 +424,11 @@ const importFilesFromPicker = async () => {
     "multiSelections",
   ]);
   if (pickedFiles.canceled || !pickedFiles) {
-    console.log("Picking files canceled or no files picked.");
     return;
   }
   const filePaths: string[] = [];
   pickedFiles.filePaths.forEach((filePath) => {
     filePaths.push(`file://${filePath}`);
-    console.log("Picked file path: ", filePath);
   });
   await paperService.create(filePaths);
 };

--- a/package.json
+++ b/package.json
@@ -100,6 +100,5 @@
     "academic",
     "paper",
     "management"
-  ],
-  "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -100,5 +100,6 @@
     "academic",
     "paper",
     "management"
-  ]
+  ],
+  "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0"
 }


### PR DESCRIPTION
Changes:
1. `showFilePicker` is able to pass props now.
2. add an menu labeled `Import From...` (other changes by prettier)
3. implement a method `importFilesFromPicker`

Related issues:
#563