### PR TITLE
Feat: Add custom CSS support 

### DIFF
--- a/app/common/services/preference-service.ts
+++ b/app/common/services/preference-service.ts
@@ -99,9 +99,8 @@ export interface IPreferenceStore {
   showWelcome: boolean;
   fontsize: "normal" | "large" | "larger";
 
-  // Custom CSS related
-  customCss: string;
-  _insertedCustomCssKey: { windowId: string, key: string }[];
+  // Custom CSS
+  customCSS: { main: string; [window: string]: string };
 }
 
 const _defaultPreferences: IPreferenceStore = {
@@ -134,7 +133,7 @@ const _defaultPreferences: IPreferenceStore = {
     { key: "volume", enable: false, width: -1 },
     { key: "number", enable: false, width: -1 },
     { key: "publisher", enable: false, width: -1 },
-    { key: "addTime", enable: true, width: -1 },
+    { key: "addTime", enable: true, width: -1 }
   ],
 
   feedFields: [
@@ -152,7 +151,7 @@ const _defaultPreferences: IPreferenceStore = {
     { key: "volume", enable: false, width: -1 },
     { key: "number", enable: false, width: -1 },
     { key: "publisher", enable: false, width: -1 },
-    { key: "addTime", enable: true, width: -1 },
+    { key: "addTime", enable: true, width: -1 }
   ],
 
   preferedTheme: "light",
@@ -225,8 +224,7 @@ const _defaultPreferences: IPreferenceStore = {
   fontsize: "normal",
 
   // Custom CSS related
-  customCss: "",
-  _insertedCustomCssKey: []
+  customCSS: { main: "" }
 };
 
 function _migrate(
@@ -254,7 +252,8 @@ function _migrate(
       if (!_defaultPreferences.hasOwnProperty(key)) {
         try {
           store.delete(key as keyof IPreferenceStore);
-        } catch (e) {}
+        } catch (e) {
+        }
       }
     }
   }
@@ -268,7 +267,7 @@ function _migrate(
       publication: [
         "showMainPublication",
         "mainPublicationWidth",
-        "feedPublicationWidth",
+        "feedPublicationWidth"
       ],
       pubType: ["showMainPubType", "mainPubTypeWidth", "feedPubTypeWidth"],
       rating: ["showMainRating", "mainRatingWidth", "feedRatingWidth"],
@@ -276,7 +275,7 @@ function _migrate(
       tags: ["showMainTag", "mainTagWidth", null],
       folders: ["showMainFolder", "mainFolderWidth", null],
       note: ["showMainNote", "mainNoteWidth", null],
-      addTime: ["showMainAddTime", "mainAddTimeWidth", "feedAddTimeWidth"],
+      addTime: ["showMainAddTime", "mainAddTimeWidth", "feedAddTimeWidth"]
     };
 
     const mainTableFields: IDataViewField[] = [];
@@ -288,7 +287,7 @@ function _migrate(
       const [preShowKey, preMainWidthKey, preFeedWidthKey] = keyMap[key] || [
         null,
         null,
-        null,
+        null
       ];
 
       const enable =
@@ -311,7 +310,7 @@ function _migrate(
       const [preShowKey, preMainWidthKey, preFeedWidthKey] = keyMap[key] || [
         null,
         null,
-        null,
+        null
       ];
 
       const enable =
@@ -358,7 +357,7 @@ export class PreferenceService extends Eventable<IPreferenceStore> {
     if (isRendererProcess()) {
       const userDataPath = ipcRenderer.sendSync("getSystemPath", "userData");
       _store = new ElectronStore<IPreferenceStore>({
-        cwd: userDataPath,
+        cwd: userDataPath
       });
     } else {
       _store = new ElectronStore<IPreferenceStore>({});

--- a/app/common/services/preference-service.ts
+++ b/app/common/services/preference-service.ts
@@ -98,6 +98,10 @@ export interface IPreferenceStore {
   showGuide: boolean;
   showWelcome: boolean;
   fontsize: "normal" | "large" | "larger";
+
+  // Custom CSS related
+  customCss: string;
+  _insertedCustomCssKey: { windowId: string, key: string }[];
 }
 
 const _defaultPreferences: IPreferenceStore = {
@@ -219,6 +223,10 @@ const _defaultPreferences: IPreferenceStore = {
   showGuide: true,
   showWelcome: true,
   fontsize: "normal",
+
+  // Custom CSS related
+  customCss: "",
+  _insertedCustomCssKey: []
 };
 
 function _migrate(

--- a/app/common/services/preference-service.ts
+++ b/app/common/services/preference-service.ts
@@ -100,7 +100,8 @@ export interface IPreferenceStore {
   fontsize: "normal" | "large" | "larger";
 
   // Custom CSS
-  customCSS: { main: string; [window: string]: string };
+  customMainWindowCSS: string;
+  customQuickPasteCSS: string;
 }
 
 const _defaultPreferences: IPreferenceStore = {
@@ -224,7 +225,8 @@ const _defaultPreferences: IPreferenceStore = {
   fontsize: "normal",
 
   // Custom CSS related
-  customCSS: { main: "" }
+  customMainWindowCSS: "",
+  customQuickPasteCSS: ""
 };
 
 function _migrate(

--- a/app/main/services/window-process-management-service.ts
+++ b/app/main/services/window-process-management-service.ts
@@ -162,6 +162,21 @@ export class WindowProcessManagementService extends Eventable<IWindowProcessMana
       });
     }
 
+     // Adding custom css
+     const insertedKeys = this._preferenceService.get("_insertedCustomCssKey") as { windowId: string, key: string }[]
+
+     if (insertedKeys.filter((i)=>i.windowId===id).length > 0) {
+       insertedKeys.filter((i)=>i.windowId===id).forEach(async (i) => {
+         await this.browserWindows.get(id).webContents.removeInsertedCSS(i.key);
+       });
+     }
+     const customCss = this._preferenceService.get("customCss") as string;
+     this.browserWindows.get(id).webContents.on("did-finish-load", async ()=>{
+         const key = await this.browserWindows.get(id).webContents.insertCSS(customCss);
+         insertedKeys.push({windowId: id, key: key});
+         this._preferenceService.set({_insertedCustomCssKey: insertedKeys});
+       });
+
     this.fire({ [id]: "created" });
   }
 

--- a/app/renderer/ui/preference-view/mainview-view.vue
+++ b/app/renderer/ui/preference-view/mainview-view.vue
@@ -239,8 +239,14 @@ const updatePref = (key: keyof IPreferenceStore, value: unknown) => {
 
     <textarea
       class="w-full h-32 p-2 mt-2 bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300"
-      v-model="prefState.customCss"
+      v-model="prefState.customCSS.main"
     ></textarea>
+    <button
+      class="w-full mt-2 p-2 bg-primary-500 text-white rounded-md"
+      @click="() => PLMainAPI.insertCustomCSS(prefState.customCSS.main)"
+    >
+      {{ $t("preference.save") }}
+    </button>
 
 
   </div>

--- a/app/renderer/ui/preference-view/mainview-view.vue
+++ b/app/renderer/ui/preference-view/mainview-view.vue
@@ -12,6 +12,7 @@ import { FieldTemplate } from "@/renderer/types/data-view";
 import Toggle from "./components/toggle.vue";
 import MainField from "./components/main-field.vue";
 import { IPreferenceStore } from "@/common/services/preference-service";
+import { Process } from "@/base/process-id";
 
 const prefState = preferenceService.useState();
 
@@ -168,6 +169,14 @@ onMounted(() => {
 const updatePref = (key: keyof IPreferenceStore, value: unknown) => {
   preferenceService.set({ [key]: value });
 };
+
+const onInsertMainCssCliecked = async () => {
+  await PLMainAPI.windowProcessManagementService.insertCustomCSS(Process.renderer, prefState.customMainWindowCSS);
+};
+
+const onInsertQuickPasteCssCliecked = async () => {
+  await PLMainAPI.windowProcessManagementService.insertCustomCSS(Process.quickpaste, prefState.customQuickPasteCSS);
+};
 </script>
 
 <template>
@@ -234,20 +243,35 @@ const updatePref = (key: keyof IPreferenceStore, value: unknown) => {
     </div>
 
     <div class="text-base font-semibold mt-4">
-        {{ $t("preference.custom") + " CSS" }}
+        {{ $t("preference.custom") + " Main CSS" }}
+    </div>
+    <div class="flex justify-between flex-col gap-3">
+      <textarea
+        class="w-full h-32 p-2 mt-2 bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300"
+        v-model="prefState.customMainWindowCSS"
+      ></textarea>
+      <button
+        class="flex h-8 w-[5.5rem] text-center rounded-md bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 hover:dark:bg-neutral-600"
+        @click="onInsertMainCssCliecked"
+      >
+        {{ $t("menu.save") }}
+      </button>
     </div>
 
-    <textarea
-      class="w-full h-32 p-2 mt-2 bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300"
-      v-model="prefState.customCSS.main"
-    ></textarea>
-    <button
-      class="w-full mt-2 p-2 bg-primary-500 text-white rounded-md"
-      @click="() => PLMainAPI.insertCustomCSS(prefState.customCSS.main)"
-    >
-      {{ $t("preference.save") }}
-    </button>
-
-
+    <div class="text-base font-semibold mt-4">
+        {{ $t("preference.custom") + $t("preference.mainview") + " Quick Paste CSS" }}
+        </div>
+        <div class="flex justify-between flex-col gap-3">
+          <textarea
+            class="w-full h-32 p-2 mt-2 bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300"
+            v-model="prefState.customQuickPasteCSS"
+          ></textarea>
+          <button
+            class="flex h-8 w-[5.5rem] text-center rounded-md bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 hover:dark:bg-neutral-600"
+            @click="onInsertQuickPasteCssCliecked"
+          >
+            {{ $t("menu.save") }}
+          </button>
+      </div>
   </div>
 </template>

--- a/app/renderer/ui/preference-view/mainview-view.vue
+++ b/app/renderer/ui/preference-view/mainview-view.vue
@@ -233,5 +233,15 @@ const updatePref = (key: keyof IPreferenceStore, value: unknown) => {
       />
     </div>
 
+    <div class="text-base font-semibold mt-4">
+        {{ $t("preference.custom") + " CSS" }}
+    </div>
+
+    <textarea
+      class="w-full h-32 p-2 mt-2 bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-300"
+      v-model="prefState.customCss"
+    ></textarea>
+
+
   </div>
 </template>


### PR DESCRIPTION
Fix #273 

This PR provides a field for custom CSS styles in the preference settings page and sets the provided CSS value when every window renders. 

- [x] Custom CSS in preference storage and service
- [x] Insert CSS when creating a window
- [x] Support custom CSS value editing in preference UI
- [ ] ~~Validate CSS syntax~~
