### PR TITLE
Enhancement: Direct Links button to HTML and Translated Paper Versions

### DIFF
--- a/app/renderer/ui/main-view/detail-view/components/online-resources.vue
+++ b/app/renderer/ui/main-view/detail-view/components/online-resources.vue
@@ -41,6 +41,22 @@ const onCodeClick = (codeJSONstr: string) => {
         </div>
         <div 
           class="flex space-x-1 bg-neutral-200 dark:bg-neutral-700 rounded-md p-1 hover:bg-neutral-300 hover:dark:bg-neutral-600 hover:shadow-sm select-none cursor-pointer mb-1 mr-1"
+          v-if="arxiv"
+          @click="onLinkClick(`https://arxiv.org/html/${arxiv.toLowerCase().replaceAll('arxiv:', '').trim()}`)"
+        >
+          <BIconLink class="text-xs my-auto" />
+          <div class="text-xxs my-auto">arXiv HTML</div>
+        </div>
+        <div 
+          class="flex space-x-1 bg-neutral-200 dark:bg-neutral-700 rounded-md p-1 hover:bg-neutral-300 hover:dark:bg-neutral-600 hover:shadow-sm select-none cursor-pointer mb-1 mr-1"
+          v-if="arxiv"
+          @click="onLinkClick(`https://arxiv.org/html/${arxiv.toLowerCase().replaceAll('arxiv:', '').trim()}?_immersive_translate_auto_translate=1`)"
+        >
+          <BIconLink class="text-xs my-auto" />
+          <div class="text-xxs my-auto">arXiv翻译</div>
+        </div>
+        <div 
+          class="flex space-x-1 bg-neutral-200 dark:bg-neutral-700 rounded-md p-1 hover:bg-neutral-300 hover:dark:bg-neutral-600 hover:shadow-sm select-none cursor-pointer mb-1 mr-1"
           v-if="doi"
           @click="onLinkClick(`https://doi.org/${doi}`)"
         >


### PR DESCRIPTION
## Background

With the rise of immersive translation plugins, reading research papers in HTML format and using these plugins for quick comprehension has become a common practice. However, the previous implementation of the online resources section only allowed users to navigate to the arXiv page, requiring additional manual steps to open the HTML version or a translated version using an immersive translation plugin.

## Changes Introduced

To improve usability and streamline access, this update introduces:

- A direct link button to open the HTML version of the paper.
- A direct link button to access the HTML version translated via an immersive translation plugin.
These enhancements eliminate unnecessary manual operations, providing a more efficient reading experience.

## Impact

Improved accessibility: Users can now access the desired format with a single click.
Enhanced workflow efficiency: Faster access to translated content saves time and effort.
![longshot20250317173037](https://github.com/user-attachments/assets/c1d5f83e-8f35-456f-9860-f9a5f18e4724)


