### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable version of paperlib receives security updates. Make sure you are running the most recent release.
+
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security problems. Instead, use GitHub's "Report a vulnerability" feature in the Security tab of this repository. We will review and respond as soon as possible.
+
+## Security Updates
+
+If we fix a vulnerability, we will announce it in the release notes. Keep your installation up to date to receive the latest fixes.


### PR DESCRIPTION
Hi paperlib developers (future scholars),

Thank you for your effort in developing paperlib!

To help with the security of paperlib, could you please enable the private **vulnerability reporting option** on the repository’s Security tab? I’ve drafted a SECURITY.md file to guide responsible vulnerability disclosure. Feel free to update it as you see fit.

Thank you!
Jianjia