### PR TITLE
fix: clarify markdown note placeholder

### DIFF
--- a/app/renderer/ui/edit-view/edit-view.vue
+++ b/app/renderer/ui/edit-view/edit-view.vue
@@ -286,7 +286,7 @@ onMounted(() => {
             />
             <InputField
               :placeholder="
-                $t('mainview.note') + ' (start with `<md> to use markdown`)'
+                $t('mainview.note') + ' (start with <md> to use Markdown)'
               "
               class="h-44 col-span-2"
               :value="editingPaperEntityDraft.note"


### PR DESCRIPTION
## Summary
- remove the misleading backtick from the note placeholder
- clarify that Markdown notes should start with the literal <md> prefix

Fixes #678.

## Test
- rg -n 'start with|<md>|use Markdown|use markdown' app/renderer/ui/edit-view/edit-view.vue
- git diff --check

Note: I did not run the full Electron/Vue typecheck because this fresh checkout has no node_modules installed and this patch only changes one UI string.